### PR TITLE
Add Llama3 VQA training config

### DIFF
--- a/MiniGPT4_Train.md
+++ b/MiniGPT4_Train.md
@@ -38,4 +38,13 @@ Then, run the following command. In our experiments, we use 1 A100.
 torchrun --nproc-per-node NUM_GPU train.py --cfg-path train_configs/minigpt4_stage2_finetune.yaml
 ```
 
-After the second stage alignment, MiniGPT-4 is able to talk about the image coherently and user-friendly. 
+After the second stage alignment, MiniGPT-4 is able to talk about the image coherently and user-friendly.
+
+## Training Llama 3.1 on VQAv2
+
+To finetune MiniGPT-4 with Llama&nbsp;3.1 on the VQAv2 dataset, set up the paths in
+`train_configs/minigpt4_llama3_vqa_finetune.yaml` and launch training with:
+
+```bash
+torchrun --nproc-per-node NUM_GPU train.py --cfg-path train_configs/minigpt4_llama3_vqa_finetune.yaml
+```

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ This configuration requires about 23G GPU memory for 13B LLM and 11.5G GPU memor
 For more powerful GPUs, you can run the model
 in 16 bit by setting `low_resource` to `False` in the relevant config file:
 
-* MiniGPT-v2: [minigptv2_eval.yaml](eval_configs/minigptv2_eval.yaml#6) 
+* MiniGPT-v2: [minigptv2_eval.yaml](eval_configs/minigptv2_eval.yaml#6)
 * MiniGPT-4 (Llama2): [minigpt4_llama2_eval.yaml](eval_configs/minigpt4_llama2_eval.yaml#6)
 * MiniGPT-4 (Vicuna): [minigpt4_eval.yaml](eval_configs/minigpt4_eval.yaml#6)
+* MiniGPT-4 (Llama3.1 VQA): [minigpt4_llama3_vqa_finetune.yaml](train_configs/minigpt4_llama3_vqa_finetune.yaml)
 
 Thanks [@WangRongsheng](https://github.com/WangRongsheng), you can also run MiniGPT-4 on [Colab](https://colab.research.google.com/drive/1OK4kYsZphwt5DXchKkzMBjYF6jnkqh4R?usp=sharing)
 

--- a/demo.py
+++ b/demo.py
@@ -52,8 +52,11 @@ def setup_seeds(config):
 #             Model Initialization
 # ========================================
 
-conv_dict = {'pretrain_vicuna0': CONV_VISION_Vicuna0,
-             'pretrain_llama2': CONV_VISION_LLama2}
+conv_dict = {
+    'pretrain_vicuna0': CONV_VISION_Vicuna0,
+    'pretrain_llama2': CONV_VISION_LLama2,
+    'pretrain_llama3': CONV_VISION_LLama3,
+}
 
 print('Initializing Chat')
 args = parse_args()

--- a/minigpt4/configs/models/minigpt4_llama3.yaml
+++ b/minigpt4/configs/models/minigpt4_llama3.yaml
@@ -1,0 +1,29 @@
+model:
+  arch: minigpt4
+
+  # vit encoder
+  image_size: 224
+  drop_path_rate: 0
+  use_grad_checkpoint: False
+  vit_precision: "fp16"
+  freeze_vit: True
+  has_qformer: False
+
+  # generation configs
+  prompt: ""
+
+  llama_model: "please set this value to the path of llama-3.1"
+
+preprocess:
+    vis_processor:
+        train:
+            name: "blip2_image_train"
+            image_size: 224
+        eval:
+            name: "blip2_image_eval"
+            image_size: 224
+    text_processor:
+        train:
+            name: "blip_caption"
+        eval:
+            name: "blip_caption"

--- a/minigpt4/conversation/conversation.py
+++ b/minigpt4/conversation/conversation.py
@@ -127,6 +127,17 @@ CONV_VISION_LLama2 = Conversation(
     sep="",
 )
 
+CONV_VISION_LLama3 = Conversation(
+    system="<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
+           "Give the following image: <Img>ImageContent</Img>. "
+           "You will be able to see the image once I provide it to you. Please answer my questions.",
+    roles=("<|start_header_id|>user<|end_header_id|>\n", "<|start_header_id|>assistant<|end_header_id|>\n"),
+    messages=[],
+    offset=2,
+    sep_style=SeparatorStyle.SINGLE,
+    sep="<|eot_id|>",
+)
+
 CONV_VISION_minigptv2 = Conversation(
     system="",
     roles=("<s>[INST] ", " [/INST]"),

--- a/minigpt4/models/minigpt4.py
+++ b/minigpt4/models/minigpt4.py
@@ -20,6 +20,7 @@ class MiniGPT4(MiniGPTBase):
     PRETRAINED_MODEL_CONFIG_DICT = {
         "pretrain_vicuna0": "configs/models/minigpt4_vicuna0.yaml",
         "pretrain_llama2": "configs/models/minigpt4_llama2.yaml",
+        "pretrain_llama3": "configs/models/minigpt4_llama3.yaml",
     }
 
     def __init__(

--- a/train_configs/minigpt4_llama3_vqa_finetune.yaml
+++ b/train_configs/minigpt4_llama3_vqa_finetune.yaml
@@ -1,0 +1,52 @@
+model:
+  arch: minigpt4
+  model_type: pretrain_llama3
+
+  max_txt_len: 160
+  end_sym: "</s>"
+  prompt_path: "prompts/alignment.txt"
+  prompt_template: '<|start_header_id|>user<|end_header_id|>\n{}<|eot_id|><|start_header_id|>assistant<|end_header_id|> '
+  ckpt: '/path/to/stage1/checkpoint/'
+
+
+datasets:
+  coco_vqa:
+    batch_size: 12
+    vis_processor:
+      train:
+        name: "blip2_image_train"
+        image_size: 224
+    text_processor:
+      train:
+        name: "blip_caption"
+
+run:
+  task: image_text_pretrain
+  # optimizer
+  lr_sched: "linear_warmup_cosine_lr"
+  init_lr: 3e-5
+  min_lr: 1e-5
+  warmup_lr: 1e-6
+
+  weight_decay: 0.05
+  max_epoch: 5
+  iters_per_epoch: 200
+  num_workers: 4
+  warmup_steps: 200
+
+  seed: 42
+  output_dir: "output/minigpt4_llama3_vqa"
+
+  amp: True
+  resume_ckpt_path: null
+
+  evaluate: False
+  train_splits: ["train"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True
+
+  wandb_log: True
+  job_name: minigpt4_llama3_vqa_finetune


### PR DESCRIPTION
## Summary
- define conversation template for Llama 3
- support `pretrain_llama3` model type
- add model config for Llama 3
- provide VQAv2 finetuning config for Llama 3
- document new training option
- update Llama 3 prompt style

## Testing
- `python -m py_compile minigpt4/conversation/conversation.py demo.py minigpt4/models/minigpt4.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ab63f3b8c8330b47e395f34f09c91