### PR TITLE
Add Llama3 training configs

### DIFF
--- a/MiniGPT4_Train.md
+++ b/MiniGPT4_Train.md
@@ -48,3 +48,16 @@ To finetune MiniGPT-4 with Llama&nbsp;3.1 on the VQAv2 dataset, set up the paths
 ```bash
 torchrun --nproc-per-node NUM_GPU train.py --cfg-path train_configs/minigpt4_llama3_vqa_finetune.yaml
 ```
+
+## Training Llama 3 from Scratch
+
+MiniGPT-4 can also be trained from scratch using Llama&nbsp;3. The process
+includes the same two-stage alignment. Launch the stages with:
+
+```bash
+bash train_llama3_from_scratch.sh NUM_GPU
+```
+
+The script runs stage&nbsp;1 using
+`train_configs/minigpt4_llama3_stage1_pretrain.yaml` followed by stage&nbsp;2
+with `train_configs/minigpt4_llama3_stage2_finetune.yaml`.

--- a/train_configs/minigpt4_llama3_stage1_pretrain.yaml
+++ b/train_configs/minigpt4_llama3_stage1_pretrain.yaml
@@ -1,0 +1,58 @@
+model:
+  arch: minigpt4
+model_type: pretrain_llama3
+
+
+datasets:
+  laion:
+    batch_size: 64
+    vis_processor:
+      train:
+        name: "blip2_image_train"
+        image_size: 224
+    text_processor:
+      train:
+        name: "blip_caption"
+    sample_ratio: 115
+  cc_sbu:
+    batch_size: 64
+    vis_processor:
+        train:
+          name: "blip2_image_train"
+          image_size: 224
+    text_processor:
+        train:
+          name: "blip_caption"
+    sample_ratio: 14
+
+
+run:
+  task: image_text_pretrain
+  # optimizer
+  lr_sched: "linear_warmup_cosine_lr"
+  init_lr: 1e-4
+  min_lr: 8e-5
+  warmup_lr: 1e-6
+
+  weight_decay: 0.05
+  max_epoch: 4
+  num_workers: 4
+  warmup_steps: 5000
+  iters_per_epoch: 5000
+
+  seed: 42
+  output_dir: "output/minigpt4_stage1_pretrain"
+
+  amp: True
+  resume_ckpt_path: null
+
+  evaluate: False 
+  train_splits: ["train"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True
+
+  wandb_log: True
+job_name: minigpt4_llama3_pretrain

--- a/train_configs/minigpt4_llama3_stage2_finetune.yaml
+++ b/train_configs/minigpt4_llama3_stage2_finetune.yaml
@@ -1,0 +1,52 @@
+model:
+  arch: minigpt4
+model_type: pretrain_llama3
+
+  max_txt_len: 160
+  end_sym: "</s>"
+  prompt_path: "prompts/alignment.txt"
+prompt_template: '<|start_header_id|>user<|end_header_id|>\n{}<|eot_id|><|start_header_id|>assistant<|end_header_id|> '
+  ckpt: '/path/to/stage1/checkpoint/'
+
+
+datasets:
+  cc_sbu_align:
+    batch_size: 12
+    vis_processor:
+      train:
+        name: "blip2_image_train"
+        image_size: 224
+    text_processor:
+      train:
+        name: "blip_caption"
+
+run:
+  task: image_text_pretrain
+  # optimizer
+  lr_sched: "linear_warmup_cosine_lr"
+  init_lr: 3e-5
+  min_lr: 1e-5
+  warmup_lr: 1e-6
+
+  weight_decay: 0.05
+  max_epoch: 5
+  iters_per_epoch: 200
+  num_workers: 4
+  warmup_steps: 200
+
+  seed: 42
+  output_dir: "output/minigpt4_stage2_finetune"
+
+  amp: True
+  resume_ckpt_path: null
+
+  evaluate: False 
+  train_splits: ["train"]
+
+  device: "cuda"
+  world_size: 1
+  dist_url: "env://"
+  distributed: True
+
+  wandb_log: True
+job_name: minigpt4_llama3_finetune

--- a/train_llama3_from_scratch.sh
+++ b/train_llama3_from_scratch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Train MiniGPT-4 with Llama 3 in two stages
+# Usage: bash train_llama3_from_scratch.sh NUM_GPU
+
+NUM_GPU=${1:-1}
+
+# Stage 1 pretraining
+torchrun --nproc-per-node $NUM_GPU train.py --cfg-path train_configs/minigpt4_llama3_stage1_pretrain.yaml
+
+# Stage 2 finetuning
+torchrun --nproc-per-node $NUM_GPU train.py --cfg-path train_configs/minigpt4_llama3_stage2_finetune.yaml
+


### PR DESCRIPTION
## Summary
- add Llama3 stage1 pretraining config
- add Llama3 stage2 finetuning config
- add helper script to train Llama3 model from scratch
- document new script in training guide

## Testing
- `python -m py_compile train.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac75af6a48330b52f45eaf4c45102